### PR TITLE
Update rid to 0.1.1.

### DIFF
--- a/Formula/rid.rb
+++ b/Formula/rid.rb
@@ -1,11 +1,11 @@
 class Rid < Formula
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.1'.freeze
 
   desc %q{Run commands in container as if were native}
   homepage 'https://github.com/creasty/rid'
   url "https://github.com/creasty/rid/releases/download/v#{VERSION}/rid-darwin-amd64.tar.gz"
   version VERSION
-  sha256 '877cba877da68e6622b472cded043735ae27b85ebef606f4a3f1401f3fd39f38'
+  sha256 'c05b02cd8635f6ad1c8c0eb78b10c11e180747d38c96968b3dc90f541ec3cc7d'
 
   def install
     bin.install 'rid'


### PR DESCRIPTION
As described in [the issue](https://github.com/creasty/rid/issues/19) it's very confusing to our interns! I'd like to have it upgraded as soon as possible.